### PR TITLE
Fix URL to xkcd

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Linux (and untested MacOSX) support is currently maintained at [Duncaen/OpenDoas
 
 ![sandwich](https://cloud.githubusercontent.com/assets/13654546/9128676/a583cd0a-3c9a-11e5-9b4f-e03ab0ba37d7.png)
 
-Apologies to [Randall Monroe](http://www.xkcd.org/149/).
+Apologies to [Randall Monroe](http://xkcd.com/149/).
 
 # OpenDoas: a portable version of OpenBSD's `doas` command
 


### PR DESCRIPTION
XKCD's host was xkcd.org, but it is xkcd.com now